### PR TITLE
Add Noto font set for better emoji support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ENV SERVER_BINARY_NAME=${SERVER_BINARY_NAME}
 RUN echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | debconf-set-selections
 RUN echo 'debconf debconf/frontend select Noninteractive' | debconf-set-selections
 RUN apt update -y && apt install -y libgtk-3-dev ttf-mscorefonts-installer
+RUN apt install -y fonts-noto-color-emoji
 
 COPY --from=builder /usr/src/${SERVER_BINARY_NAME}/target/${CARGO_BUILD_MODE}/${SERVER_BINARY_NAME} /usr/local/bin/${SERVER_BINARY_NAME}
 CMD ["sh", "-c", "$SERVER_BINARY_NAME"]


### PR DESCRIPTION
Resolves #7 

As noted in the linked issue, there's some emoji that just don't render. I believe the root cause of this is that our deployment package does not contain any font packs that support the full unicode block for the standard emoji set, producing the strange rendering seen here:

https://raster.shields.io/badge/emoji-%F0%9F%91%8D-blue.png
![](https://raster.shields.io/badge/emoji-%F0%9F%91%8D-blue.png)
https://raster.shields.io/badge/emoji-%F0%9F%87%B3%F0%9F%87%B4-blue.png
![](https://raster.shields.io/badge/emoji-%F0%9F%87%B3%F0%9F%87%B4-blue.png)
https://raster.shields.io/badge/emoji-%F0%9F%90%8F-blue.png
![](https://raster.shields.io/badge/emoji-%F0%9F%90%8F-blue.png)

(screenshot included below to capture for posterity)

![image](https://user-images.githubusercontent.com/13042488/135781220-5ad535c8-f079-447e-bc44-39e6cc4e72d4.png)

I don't know enough about the various fonts to offer any opinions around which font would be "best", but I have the Noto Color Emoji font set locally in my Linux environment and it does support the full unicode block so I've added it to our runtime environment via the Docker image.

Compare the results using the review app for this PR:
https://squint-emoji-jpjkar3h0yyhbkggy.herokuapp.com/badge/emoji-%F0%9F%91%8D-blue.png
![](https://squint-emoji-jpjkar3h0yyhbkggy.herokuapp.com/badge/emoji-%F0%9F%91%8D-blue.png)
https://squint-emoji-jpjkar3h0yyhbkggy.herokuapp.com/badge/emoji-%F0%9F%87%B3%F0%9F%87%B4-blue.png
![](https://squint-emoji-jpjkar3h0yyhbkggy.herokuapp.com/badge/emoji-%F0%9F%87%B3%F0%9F%87%B4-blue.png)
https://squint-emoji-jpjkar3h0yyhbkggy.herokuapp.com/badge/emoji-%F0%9F%90%8F-blue.png
![](https://squint-emoji-jpjkar3h0yyhbkggy.herokuapp.com/badge/emoji-%F0%9F%90%8F-blue.png)

(screenshot included below to capture for posterity)

![image](https://user-images.githubusercontent.com/13042488/135781988-d54bcd44-60dc-4fd0-a8e4-47215b228301.png)
