### PR TITLE
update deps to support OpenSSL v3+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,9 +1070,9 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+checksum = "fd7e2f3618557f980e0b17e8856252eee3c97fa12c54dff0ca290fb6266ca4a9"
 dependencies = [
  "lazy_static",
  "libc",
@@ -1193,22 +1193,34 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "2f7254b99e31cad77da24b08ebf628882739a608578bb1bcdfc1f9c21260d7c0"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
+ "openssl-macros",
  "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1219,9 +1231,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.58"
+version = "0.9.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
 dependencies = [
  "autocfg",
  "cc",

--- a/src/badge.rs
+++ b/src/badge.rs
@@ -1,4 +1,7 @@
-#[derive(std::fmt::Debug, std::cmp::PartialEq)]
+use std::cmp::{Eq, PartialEq};
+use std::fmt::Debug;
+
+#[derive(Debug, Eq, PartialEq)]
 pub enum BadgeStyle {
     Flat,
     FlatSquare,

--- a/src/graphics/raster.rs
+++ b/src/graphics/raster.rs
@@ -1,3 +1,6 @@
+use std::cmp::{Eq, PartialEq};
+use std::fmt::Debug;
+
 use super::{SvgProcessor, INVALID_SVG};
 use crate::badge::BadgeStyle;
 
@@ -9,7 +12,7 @@ use gio::{MemoryInputStream, NONE_CANCELLABLE, NONE_FILE};
 use glib::Bytes;
 use librsvg::IntrinsicDimensions;
 
-#[derive(std::fmt::Debug, std::cmp::PartialEq)]
+#[derive(Debug, Eq, PartialEq)]
 pub enum SvgToPngConversionError {
     ImageContextCreationFailure,
     ImageSurfaceCreationFailure,


### PR DESCRIPTION
I've updated to an OS version which utilizes OpenSSL v3, and we'll run into the same whenever we get back around to the updates needed for #78.

In the interim, I'd like to go ahead and update some of our transitive dependencies to newer versions which bring support for OpenSSL v3. Note that I've tested this locally for emoji compatibility out of an abundance of caution, and as expected this does not introduce any emoji related issues.